### PR TITLE
#7 Fix that service is not restarted when changing the metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 
+## [Unreleased](https://github.com/idealista/prometheus_oracle_exporter_role/tree/develop)
+
+### Fixed
+- *[#7](https://github.com/idealista/prometheus_oracle_exporter_role/issues/7) Fix that service is not restarted when changing the metrics* @pablogcaldito
+
 ## [1.0.0](https://github.com/idealista/prometheus_oracle_exporter_role/tree/1.0.0) (2020-03-10)
 
 ### Added

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -7,4 +7,5 @@
     owner: "{{ oracle_exporter_user }}"
     group: "{{ oracle_exporter_group }}"
     mode: 0664
+  notify: restart oracle_exporter
   when: oracle_exporter_custom_metrics_path is defined


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Notify the handler to restart the service when the metrics are changed

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->


### Benefits

The oracle exporter service is restarted when the metrics are changed

### Possible Drawbacks

None

### Applicable Issues

#7 

<!-- Enter any applicable Issues here -->