### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ## [Unreleased](https://github.com/idealista/prometheus_oracle_exporter_role/tree/develop)
 
 ## [1.1.0](https://github.com/idealista/prometheus_oracle_exporter_role/tree/1.1.0) (2020-03-18)
+[Full Changelog](https://github.com/idealista/prometheus_oracle_exporter_role/compare/1.0.0...1.1.0)
 ### Fixed
 - *[#6](https://github.com/idealista/prometheus_oracle_exporter_role/issues/6) Add missing reference to oracle instant client role in Readme* @pablogcaldito
 - *[#5](https://github.com/idealista/prometheus_oracle_exporter_role/issues/5) Fix example's version typo in Readme* @pablogcaldito


### PR DESCRIPTION
### Fixed
- *[#6](https://github.com/idealista/prometheus_oracle_exporter_role/issues/6) Add missing reference to oracle instant client role in Readme* @pablogcaldito
- *[#5](https://github.com/idealista/prometheus_oracle_exporter_role/issues/5) Fix example's version typo in Readme* @pablogcaldito
- *[#8](https://github.com/idealista/prometheus_oracle_exporter_role/issues/8) Fix that there was not an option to set up the NLS_LANG environment variable for the service* @pablogcaldito
- *[#2](https://github.com/idealista/prometheus_oracle_exporter_role/issues/2) Update ansible version from 2.8.6 to 2.8.8* @pablogcaldito
- *[#7](https://github.com/idealista/prometheus_oracle_exporter_role/issues/7) Fix that service is not restarted when changing the metrics* @pablogcaldito